### PR TITLE
Update 'release-script' to human friendly version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "test": "npm run lint && mocha",
     "build": "rm -rf lib && babel src --out-dir lib",
     "lint": "eslint ./",
-    "patch": "release patch",
-    "minor": "release minor",
-    "major": "release major"
+    "release": "release"
   },
   "repository": {
     "type": "git",
@@ -38,7 +36,7 @@
     "is-my-json-valid": "^2.12.0",
     "mocha": "^2.2.5",
     "mt-changelog": "^0.6.1",
-    "release-script": "^0.3.0"
+    "release-script": "^0.5.0"
   },
   "keywords": [
     "eslint-plugin",


### PR DESCRIPTION
Release script runs in "dry run" mode by default.
It prevents `danger` steps (`git push`, `npm publish` etc) from accidental running.

https://github.com/AlexKVal/release-script/pull/19/files

It reminds about `--run` option like that:
<img width="533" alt="screen shot 2015-09-17 at 9 55 59 am" src="https://cloud.githubusercontent.com/assets/847572/9926955/d438177a-5d22-11e5-9975-b17e97fe165a.png">
